### PR TITLE
README: Fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use this plugin, you must already have a Drupal project using BLT 12 or highe
 
 In your project, require the plugin with Composer:
 
-`composer require –dev acquia/blt-phpcs`
+`composer require --dev acquia/blt-phpcs`
 
 # License
 


### PR DESCRIPTION
Replace en dash with double hyphen

# Before

```console
$ composer require –dev acquia/blt-phpcs


  [InvalidArgumentException]
  Could not find package –dev.

  Did you mean one of these?
      drupal/vdo
      drupal/bear
      drupal/bfd
      behat/behat
      drupal/media


require [--dev] [--dry-run] [--prefer-source] [--prefer-dist] [--fixed] [--no-suggest] [--no-progress] [--no-update] [--no-install] [--no-scripts] [--update-no-dev] [-w|--update-with-dependencies] [-W|--update-with-all-dependencies] [--with-dependencies] [--with-all-dependencies] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--] [<packages>]...
```

# After

```console
$ composer require --dev acquia/blt-phpcs
Using version ^1.0 for acquia/blt-phpcs
./composer.json has been updated
Running composer update acquia/blt-phpcs
Gathering patches for root package.
Loading composer repositories with package information
Updating dependencies
Lock file operations: 5 installs, 0 updates, 0 removals
  - Locking acquia/blt-phpcs (v1.0.0)
  - Locking acquia/coding-standards (v0.5.1)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpstan/phpdoc-parser (0.3.5)
  - Locking slevomat/coding-standard (5.0.4)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 5 installs, 0 updates, 0 removals
  - Downloading phpstan/phpdoc-parser (0.3.5)
  - Downloading slevomat/coding-standard (5.0.4)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading acquia/coding-standards (v0.5.1)
  - Downloading acquia/blt-phpcs (v1.0.0)
Gathering patches for root package.
Gathering patches for dependencies. This might take a minute.
  - Installing phpstan/phpdoc-parser (0.3.5): Extracting archive
  - Installing slevomat/coding-standard (5.0.4): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing acquia/coding-standards (v0.5.1): Extracting archive
  - Installing acquia/blt-phpcs (v1.0.0): Extracting archive
1 package suggestions were added by new dependencies, use `composer suggest` to see details.
Package container-interop/container-interop is abandoned, you should avoid using it. Use psr/container instead.
Package doctrine/reflection is abandoned, you should avoid using it. Use roave/better-reflection instead.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
composer/package-versions-deprecated: Generating version class...
composer/package-versions-deprecated: ...done generating version class
79 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
PHP CodeSniffer Config installed_paths set to ../../acquia/coding-standards/src/Standards,../../drupal/coder/coder_sniffer,../../phpcompatibility/php-compatibility,../../sirbrillig/phpcs-variable-analysis,../../slevomat/coding-standard
Scaffolding files for drupal/core:
  - Copy [project-root]/.editorconfig from assets/scaffold/files/editorconfig
  - Copy [project-root]/.gitattributes from assets/scaffold/files/gitattributes
> patch < patches/drupal/custom_editorconfig.patch
patching file .editorconfig
> patch < patches/drupal/custom_gitattributes.patch
patching file .gitattributes
```
